### PR TITLE
Move path to exec definition

### DIFF
--- a/manifests/rock.pp
+++ b/manifests/rock.pp
@@ -76,20 +76,18 @@ define luarocks::rock(
   }
 
   exec{"manage_rock_${name}":
-      command => $rock_cmd
+      command => $rock_cmd,
+      path => "/bin:/usr/bin",
   }
 
   $rock_cmd_check_str = "luarocks list | egrep -A1 '^${real_name}\\>' | tail -1 | egrep '\\<${rock_version_check_str}\\> \\(installed\\)'"
   if $ensure == 'present' {
       Exec["manage_rock_${name}"]{
          unless => $rock_cmd_check_str,
-         path => "/bin:/usr/bin",
       }
   } else {
       Exec["manage_rock_${name}"]{
          onlyif => $rock_cmd_check_str,
-         path => "/bin:/usr/bin",
       }
   }
 }
-


### PR DESCRIPTION
This allows setting a global exec path (https://www.puppetcookbook.com/posts/set-global-exec-path.html)

Without this, using a global exec path results in:
````
Error: Evaluation Error: Error while evaluating a Resource Statement, 
Parameter 'path' is already set on Exec[manage_rock_lua-resty-openidc] by #<Puppet::Resource::Type:0x00000003b785d8> at /tmp/kitchen/manifests/site.pp:10; 
cannot redefine at /tmp/kitchen/modules/luarocks/manifests/rock.pp:86
````